### PR TITLE
Fix polymorphism when loading the contents of a multivalued inlined_as_dict slot #85

### DIFF
--- a/src/runtime/tests/data/mapping_data.json
+++ b/src/runtime/tests/data/mapping_data.json
@@ -1,0 +1,15 @@
+{
+  "things": {
+    "alpha": {
+      "typeURI": "ThingA",
+      "a_only": "foo",
+      "common": "shared"
+    },
+    "beta": {
+      "typeURI": "ThingB",
+      "b_only": true,
+      "common": "shared"
+    }
+  }
+}
+

--- a/src/runtime/tests/data/mapping_schema.yaml
+++ b/src/runtime/tests/data/mapping_schema.yaml
@@ -1,0 +1,39 @@
+id: https://example.org/mapping
+name: mapping
+prefixes:
+  ex: https://example.org/
+
+default_prefix: ex
+
+classes:
+  Bag:
+    attributes:
+      things:
+        range: Thing
+        multivalued: true
+        inlined: true
+        inlined_as_list: false
+
+  Thing:
+    attributes:
+      key:
+        range: string
+        key: true
+      typeURI:
+        range: string
+        designates_type: true
+      common:
+        range: string
+
+  ThingA:
+    is_a: Thing
+    attributes:
+      a_only:
+        range: string
+
+  ThingB:
+    is_a: Thing
+    attributes:
+      b_only:
+        range: boolean
+

--- a/src/runtime/tests/inlined_mapping_subclass.rs
+++ b/src/runtime/tests/inlined_mapping_subclass.rs
@@ -1,0 +1,62 @@
+use linkml_runtime::{load_json_file, validate, LinkMLValue};
+use linkml_schemaview::identifier::{converter_from_schema, Identifier};
+use linkml_schemaview::io::from_yaml;
+use linkml_schemaview::schemaview::SchemaView;
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+#[test]
+fn inlined_mapping_selects_subclass_by_typeuri() {
+    // Load simple schema
+    let schema = from_yaml(Path::new(&data_path("mapping_schema.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+
+    // Base container class
+    let bag = sv
+        .get_class(&Identifier::new("Bag"), &conv)
+        .unwrap()
+        .expect("class not found");
+
+    // Load JSON data
+    let v = load_json_file(
+        Path::new(&data_path("mapping_data.json")),
+        &sv,
+        &bag,
+        &conv,
+    )
+    .unwrap();
+
+    // Instance should validate
+    assert!(validate(&v).is_ok());
+
+    // Ensure inlined mapping children select subclasses based on typeURI
+    match v {
+        LinkMLValue::Object { values, .. } => {
+            let things = values.get("things").expect("things slot missing");
+            match things {
+                LinkMLValue::Mapping { values, .. } => {
+                    match values.get("alpha").expect("alpha missing") {
+                        LinkMLValue::Object { class, .. } => assert_eq!(class.name(), "ThingA"),
+                        _ => panic!("alpha should be an object"),
+                    }
+                    match values.get("beta").expect("beta missing") {
+                        LinkMLValue::Object { class, .. } => assert_eq!(class.name(), "ThingB"),
+                        _ => panic!("beta should be an object"),
+                    }
+                }
+                _ => panic!("things should be a mapping"),
+            }
+        }
+        _ => panic!("expected top-level object"),
+    }
+}
+

--- a/src/runtime/tests/inlined_mapping_subclass.rs
+++ b/src/runtime/tests/inlined_mapping_subclass.rs
@@ -27,13 +27,7 @@ fn inlined_mapping_selects_subclass_by_typeuri() {
         .expect("class not found");
 
     // Load JSON data
-    let v = load_json_file(
-        Path::new(&data_path("mapping_data.json")),
-        &sv,
-        &bag,
-        &conv,
-    )
-    .unwrap();
+    let v = load_json_file(Path::new(&data_path("mapping_data.json")), &sv, &bag, &conv).unwrap();
 
     // Instance should validate
     assert!(validate(&v).is_ok());
@@ -59,4 +53,3 @@ fn inlined_mapping_selects_subclass_by_typeuri() {
         _ => panic!("expected top-level object"),
     }
 }
-


### PR DESCRIPTION
When loading data from an inlined_as_dict slot, the type designator was ignored. This PR fixes it.
