### PR TITLE
Improve null handling and diff operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 - Add integration tests under `src/runtime/tests/` when changing CLI/runtime behavior.
 - Prefer `assert_cmd` for CLI and `predicates` for output checks. Keep fixtures in `src/runtime/tests/data/`.
 - Run `cargo test --workspace` locally; ensure tests don’t rely on network input.
+ - Prefer modifying existing tests over adding new ones for new code paths. Extend current scenarios with extra assertions/fixtures to avoid redundant tests proliferating. For example, if adding null-handling in diff/patch, enhance the existing diff tests rather than introducing separate "basic diff works" tests that become redundant.
 
 ## Commit & Pull Request Guidelines
 - Commits: short, imperative summary (e.g., “Add __repr__ for LinkMLValue”); group related changes.

--- a/src/python/src/lib.rs
+++ b/src/python/src/lib.rs
@@ -734,17 +734,19 @@ fn load_json(
     Ok(PyLinkMLValue::new(v, sv))
 }
 
-#[pyfunction(name = "diff", signature = (source, target, ignore_missing_target=None))]
+#[pyfunction(name = "diff", signature = (source, target, ignore_missing_target=None, treat_missing_as_null=None))]
 fn py_diff(
     py: Python<'_>,
     source: &PyLinkMLValue,
     target: &PyLinkMLValue,
     ignore_missing_target: Option<bool>,
+    treat_missing_as_null: Option<bool>,
 ) -> PyResult<PyObject> {
     let deltas = diff_internal(
         &source.value,
         &target.value,
         ignore_missing_target.unwrap_or(false),
+        treat_missing_as_null.unwrap_or(false),
     );
     let vals: Vec<JsonValue> = deltas
         .iter()

--- a/src/python/src/lib.rs
+++ b/src/python/src/lib.rs
@@ -734,18 +734,16 @@ fn load_json(
     Ok(PyLinkMLValue::new(v, sv))
 }
 
-#[pyfunction(name = "diff", signature = (source, target, ignore_missing_target=None, treat_missing_as_null=None))]
+#[pyfunction(name = "diff", signature = (source, target, treat_missing_as_null=None))]
 fn py_diff(
     py: Python<'_>,
     source: &PyLinkMLValue,
     target: &PyLinkMLValue,
-    ignore_missing_target: Option<bool>,
     treat_missing_as_null: Option<bool>,
 ) -> PyResult<PyObject> {
     let deltas = diff_internal(
         &source.value,
         &target.value,
-        ignore_missing_target.unwrap_or(false),
         treat_missing_as_null.unwrap_or(false),
     );
     let vals: Vec<JsonValue> = deltas

--- a/src/python/src/lib.rs
+++ b/src/python/src/lib.rs
@@ -483,6 +483,7 @@ impl PyLinkMLValue {
         match &self.value {
             LinkMLValue::Scalar { slot, .. } => Some(slot.name.clone()),
             LinkMLValue::List { slot, .. } => Some(slot.name.clone()),
+            LinkMLValue::Null { slot, .. } => Some(slot.name.clone()),
             _ => None,
         }
     }
@@ -491,6 +492,7 @@ impl PyLinkMLValue {
     fn kind(&self) -> String {
         match &self.value {
             LinkMLValue::Scalar { .. } => "scalar".to_string(),
+            LinkMLValue::Null { .. } => "null".to_string(),
             LinkMLValue::List { .. } => "list".to_string(),
             LinkMLValue::Mapping { .. } => "mapping".to_string(),
             LinkMLValue::Object { .. } => "object".to_string(),
@@ -502,6 +504,7 @@ impl PyLinkMLValue {
         match &self.value {
             LinkMLValue::Scalar { slot, .. } => Some(slot.definition().clone()),
             LinkMLValue::List { slot, .. } => Some(slot.definition().clone()),
+            LinkMLValue::Null { slot, .. } => Some(slot.definition().clone()),
             _ => None,
         }
     }
@@ -512,6 +515,7 @@ impl PyLinkMLValue {
             LinkMLValue::Object { class, .. } => Some(class.def().clone()),
             LinkMLValue::Scalar { class: Some(c), .. } => Some(c.def().clone()),
             LinkMLValue::List { class: Some(c), .. } => Some(c.def().clone()),
+            LinkMLValue::Null { class: Some(c), .. } => Some(c.def().clone()),
             _ => None,
         }
     }
@@ -522,6 +526,7 @@ impl PyLinkMLValue {
             LinkMLValue::Object { class, .. } => Some(class.def().name.clone()),
             LinkMLValue::Scalar { class: Some(c), .. } => Some(c.def().name.clone()),
             LinkMLValue::List { class: Some(c), .. } => Some(c.def().name.clone()),
+            LinkMLValue::Null { class: Some(c), .. } => Some(c.def().name.clone()),
             _ => None,
         }
     }
@@ -529,6 +534,7 @@ impl PyLinkMLValue {
     fn __len__(&self) -> PyResult<usize> {
         Ok(match &self.value {
             LinkMLValue::Scalar { .. } => 0,
+            LinkMLValue::Null { .. } => 0,
             LinkMLValue::List { values, .. } => values.len(),
             LinkMLValue::Mapping { values, .. } => values.len(),
             LinkMLValue::Object { values, .. } => values.len(),
@@ -644,6 +650,9 @@ impl PyLinkMLValue {
         Ok(match &self.value {
             LinkMLValue::Scalar { value, slot, .. } => {
                 format!("LinkMLValue.Scalar(slot='{}', value={})", slot.name, value)
+            }
+            LinkMLValue::Null { slot, .. } => {
+                format!("LinkMLValue.Null(slot='{}')", slot.name)
             }
             LinkMLValue::List { values, slot, .. } => {
                 format!(

--- a/src/runtime/src/diff.rs
+++ b/src/runtime/src/diff.rs
@@ -27,6 +27,7 @@ impl LinkMLValue {
     pub fn to_json(&self) -> JsonValue {
         match self {
             LinkMLValue::Scalar { value, .. } => value.clone(),
+            LinkMLValue::Null { .. } => JsonValue::Null,
             LinkMLValue::List { values, .. } => {
                 JsonValue::Array(values.iter().map(|v| v.to_json()).collect())
             }

--- a/src/runtime/src/turtle.rs
+++ b/src/runtime/src/turtle.rs
@@ -225,6 +225,9 @@ fn serialize_map<W: Write>(
                     }
                 }
             }
+            LinkMLValue::Null { .. } => {
+                // Null is treated as absent; emit nothing
+            }
             LinkMLValue::Object { values, class, .. } => {
                 let class_ref = &class;
                 let (obj, child_id) =
@@ -287,6 +290,9 @@ fn serialize_map<W: Write>(
                                     formatter.serialize_triple(triple.as_ref())?;
                                 }
                             }
+                        }
+                        LinkMLValue::Null { .. } => {
+                            // Skip null items
                         }
                         LinkMLValue::Object {
                             values: mv, class, ..
@@ -363,6 +369,9 @@ fn serialize_map<W: Write>(
                                     formatter.serialize_triple(triple.as_ref())?;
                                 }
                             }
+                        }
+                        LinkMLValue::Null { .. } => {
+                            // nothing
                         }
                         LinkMLValue::Object {
                             values: mv, class, ..
@@ -523,6 +532,7 @@ pub fn write_turtle<W: Write>(
                             formatter.serialize_triple(triple.as_ref())?;
                         }
                     }
+                    LinkMLValue::Null { .. } => {}
                     LinkMLValue::List { .. } => {}
                     LinkMLValue::Mapping { .. } => {}
                 }
@@ -578,12 +588,16 @@ pub fn write_turtle<W: Write>(
                             formatter.serialize_triple(triple.as_ref())?;
                         }
                     }
+                    LinkMLValue::Null { .. } => {
+                        // nothing
+                    }
                     LinkMLValue::List { .. } => {}
                     LinkMLValue::Mapping { .. } => {}
                 }
             }
         }
         LinkMLValue::Scalar { .. } => {}
+        LinkMLValue::Null { .. } => {}
     }
     let out_buf = formatter.finish()?;
     let mut out = String::from_utf8(out_buf).unwrap_or_default();

--- a/src/runtime/tests/data/example_personinfo_data_nulls.yaml
+++ b/src/runtime/tests/data/example_personinfo_data_nulls.yaml
@@ -1,0 +1,11 @@
+objects:
+  - id: P:100
+    objecttype: https://w3id.org/linkml/examples/personinfo/Person
+    name: Null Collections Person
+    # multivalued scalar list
+    aliases: null
+    # inlined-as-list of class instances
+    has_employment_history: null
+    # inlined-as-dict of class instances
+    has_familial_relationships: null
+

--- a/src/runtime/tests/validation.rs
+++ b/src/runtime/tests/validation.rs
@@ -51,3 +51,39 @@ fn validate_personinfo_example2() {
     .unwrap();
     assert!(validate(&v).is_ok());
 }
+
+#[test]
+fn validate_personinfo_null_collections() {
+    let schema = from_yaml(Path::new(&info_path("personinfo.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let container = sv
+        .get_class(&Identifier::new("Container"), &conv)
+        .unwrap()
+        .expect("class not found");
+    let v = load_yaml_file(
+        Path::new(&info_path("example_personinfo_data_nulls.yaml")),
+        &sv,
+        &container,
+        &conv,
+    )
+    .unwrap();
+    assert!(validate(&v).is_ok());
+    // Assert that nulls are preserved as LinkMLValue::Null (not empty collections)
+    if let linkml_runtime::LinkMLValue::Object { values, .. } = &v {
+        if let Some(linkml_runtime::LinkMLValue::List { values: objs, .. }) = values.get("objects") {
+            if let Some(linkml_runtime::LinkMLValue::Object { values: person, .. }) = objs.get(0) {
+                assert!(matches!(person.get("aliases"), Some(linkml_runtime::LinkMLValue::Null { .. })));
+                assert!(matches!(person.get("has_employment_history"), Some(linkml_runtime::LinkMLValue::Null { .. })));
+                assert!(matches!(person.get("has_familial_relationships"), Some(linkml_runtime::LinkMLValue::Null { .. })));
+            } else {
+                panic!("expected first object to be an Object");
+            }
+        } else {
+            panic!("expected Container.objects to be a List");
+        }
+    } else {
+        panic!("expected root to be an Object");
+    }
+}

--- a/src/runtime/tests/validation.rs
+++ b/src/runtime/tests/validation.rs
@@ -72,11 +72,21 @@ fn validate_personinfo_null_collections() {
     assert!(validate(&v).is_ok());
     // Assert that nulls are preserved as LinkMLValue::Null (not empty collections)
     if let linkml_runtime::LinkMLValue::Object { values, .. } = &v {
-        if let Some(linkml_runtime::LinkMLValue::List { values: objs, .. }) = values.get("objects") {
-            if let Some(linkml_runtime::LinkMLValue::Object { values: person, .. }) = objs.get(0) {
-                assert!(matches!(person.get("aliases"), Some(linkml_runtime::LinkMLValue::Null { .. })));
-                assert!(matches!(person.get("has_employment_history"), Some(linkml_runtime::LinkMLValue::Null { .. })));
-                assert!(matches!(person.get("has_familial_relationships"), Some(linkml_runtime::LinkMLValue::Null { .. })));
+        if let Some(linkml_runtime::LinkMLValue::List { values: objs, .. }) = values.get("objects")
+        {
+            if let Some(linkml_runtime::LinkMLValue::Object { values: person, .. }) = objs.first() {
+                assert!(matches!(
+                    person.get("aliases"),
+                    Some(linkml_runtime::LinkMLValue::Null { .. })
+                ));
+                assert!(matches!(
+                    person.get("has_employment_history"),
+                    Some(linkml_runtime::LinkMLValue::Null { .. })
+                ));
+                assert!(matches!(
+                    person.get("has_familial_relationships"),
+                    Some(linkml_runtime::LinkMLValue::Null { .. })
+                ));
             } else {
                 panic!("expected first object to be an Object");
             }

--- a/src/tools/src/bin/linkml_diff.rs
+++ b/src/tools/src/bin/linkml_diff.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let src = load_value(&args.source, &sv, &class_view, &conv)?;
     let tgt = load_value(&args.target, &sv, &class_view, &conv)?;
-    let deltas = diff(&src, &tgt, false, false);
+    let deltas = diff(&src, &tgt, false);
 
     let mut writer: Box<dyn Write> = if let Some(out) = &args.output {
         Box::new(File::create(out)?)

--- a/src/tools/src/bin/linkml_diff.rs
+++ b/src/tools/src/bin/linkml_diff.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let src = load_value(&args.source, &sv, &class_view, &conv)?;
     let tgt = load_value(&args.target, &sv, &class_view, &conv)?;
-    let deltas = diff(&src, &tgt, false);
+    let deltas = diff(&src, &tgt, false, false);
 
     let mut writer: Box<dyn Write> = if let Some(out) = &args.output {
         Box::new(File::create(out)?)


### PR DESCRIPTION
- Preserve explicit nulls via LinkMLValue::Null and skip serialization
- Diff: single flag treat_missing_as_null; null changes are updates; add/remove ops for list/dict
- Python: expose treat_missing_as_null in diff(); handle "null" kind in bindings
- Tests: extend existing suites to cover nulls and collection add/remove