### PR TITLE
Add NodeIds to LinkMLValue and return PatchTrace from patch()

### DIFF
--- a/src/runtime/tests/diff.rs
+++ b/src/runtime/tests/diff.rs
@@ -57,7 +57,7 @@ fn diff_and_patch_person() {
         }
     }
 
-    let patched = patch(&src, &deltas, &sv);
+    let (patched, _trace) = patch(&src, &deltas, &sv);
     let patched_json = patched.to_json();
     let target_json = tgt.to_json();
     let src_json = src.to_json();
@@ -93,7 +93,7 @@ fn diff_ignore_missing_target() {
 
     let deltas = diff(&src, &tgt, true);
     assert!(deltas.is_empty());
-    let patched = patch(&src, &deltas, &sv);
+    let (patched, _trace) = patch(&src, &deltas, &sv);
     let patched_json = patched.to_json();
     let src_json = src.to_json();
     assert_eq!(patched_json, src_json);
@@ -135,7 +135,7 @@ fn diff_and_patch_personinfo() {
             assert!(tgt.navigate_path(&d.path).is_some());
         }
     }
-    let patched = patch(&src, &deltas, &sv);
+    let (patched, _trace) = patch(&src, &deltas, &sv);
     assert_eq!(patched.to_json(), tgt.to_json());
 }
 

--- a/src/runtime/tests/trace.rs
+++ b/src/runtime/tests/trace.rs
@@ -1,0 +1,126 @@
+use linkml_runtime::{diff, load_json_str, load_yaml_file};
+use linkml_schemaview::identifier::{converter_from_schema, Identifier};
+use linkml_schemaview::io::from_yaml;
+use linkml_schemaview::schemaview::SchemaView;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+fn data_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+fn info_path(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("data");
+    p.push(name);
+    p
+}
+
+fn collect_ids(v: &linkml_runtime::LinkMLValue, out: &mut Vec<u64>) {
+    out.push(v.node_id());
+    match v {
+        linkml_runtime::LinkMLValue::Scalar { .. } => {}
+        linkml_runtime::LinkMLValue::List { values, .. } => {
+            for c in values {
+                collect_ids(c, out);
+            }
+        }
+        linkml_runtime::LinkMLValue::Mapping { values, .. }
+        | linkml_runtime::LinkMLValue::Object { values, .. } => {
+            for c in values.values() {
+                collect_ids(c, out);
+            }
+        }
+    }
+}
+
+#[test]
+fn node_ids_preserved_scalar_update() {
+    let schema = from_yaml(Path::new(&data_path("schema.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let class = sv
+        .get_class(&Identifier::new("Person"), &conv)
+        .unwrap()
+        .expect("class not found");
+    let src = load_yaml_file(
+        Path::new(&data_path("person_valid.yaml")),
+        &sv,
+        &class,
+        &conv,
+    )
+    .unwrap();
+    let mut tgt_json = src.to_json();
+    if let serde_json::Value::Object(ref mut m) = tgt_json {
+        m.insert("age".to_string(), serde_json::json!(99));
+    }
+    let tgt = load_json_str(&serde_json::to_string(&tgt_json).unwrap(), &sv, &class, &conv)
+        .unwrap();
+
+    let deltas = diff(&src, &tgt, false);
+    let (patched, trace) = linkml_runtime::patch(&src, &deltas, &sv);
+
+    assert!(trace.added.is_empty());
+    assert!(trace.deleted.is_empty());
+    assert!(!trace.updated.is_empty());
+
+    let src_age = src.navigate_path(["age"]).unwrap();
+    let pat_age = patched.navigate_path(["age"]).unwrap();
+    assert_eq!(src_age.node_id(), pat_age.node_id());
+    assert!(trace.updated.contains(&pat_age.node_id()));
+}
+
+#[test]
+fn patch_trace_add_in_list() {
+    let schema = from_yaml(Path::new(&info_path("personinfo.yaml"))).unwrap();
+    let mut sv = SchemaView::new();
+    sv.add_schema(schema.clone()).unwrap();
+    let conv = converter_from_schema(&schema);
+    let container = sv
+        .get_class(&Identifier::new("Container"), &conv)
+        .unwrap()
+        .expect("class not found");
+    let base = load_yaml_file(
+        Path::new(&info_path("example_personinfo_data.yaml")),
+        &sv,
+        &container,
+        &conv,
+    )
+    .unwrap();
+
+    // Add a new object to the 'objects' list
+    let mut base_json = base.to_json();
+    if let serde_json::Value::Object(ref mut root) = base_json {
+        if let Some(serde_json::Value::Array(ref mut arr)) = root.get_mut("objects") {
+            let new_obj = serde_json::json!({
+                "id": "P:999",
+                "name": "Added Person",
+                "objecttype": "https://w3id.org/linkml/examples/personinfo/Person"
+            });
+            arr.push(new_obj);
+        }
+    }
+    let target = load_json_str(&serde_json::to_string(&base_json).unwrap(), &sv, &container, &conv)
+        .unwrap();
+
+    let deltas = diff(&base, &target, false);
+    let mut pre = Vec::new();
+    collect_ids(&base, &mut pre);
+    let (patched, trace) = linkml_runtime::patch(&base, &deltas, &sv);
+    let mut post = Vec::new();
+    collect_ids(&patched, &mut post);
+
+    let pre_set: HashSet<u64> = pre.into_iter().collect();
+    let post_set: HashSet<u64> = post.into_iter().collect();
+    let added: HashSet<u64> = post_set.difference(&pre_set).copied().collect();
+    let trace_added: HashSet<u64> = trace.added.iter().copied().collect();
+    assert_eq!(added, trace_added);
+    assert!(!added.is_empty());
+}
+

--- a/src/tools/src/bin/linkml_patch.rs
+++ b/src/tools/src/bin/linkml_patch.rs
@@ -92,7 +92,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         serde_yaml::from_str(&delta_text)?
     };
-    let patched = patch(&src, &deltas, &sv);
+    let (patched, _trace) = patch(&src, &deltas, &sv);
     write_value(args.output.as_deref(), &patched)?;
     Ok(())
 }


### PR DESCRIPTION
Implements provenance-ready core changes per asset360 design:

- Add stable NodeIds (u64) to every LinkMLValue node. NodeIds are assigned on construct via a global AtomicU64.
- Change patch() to return (LinkMLValue, PatchTrace) where PatchTrace = {added, deleted, updated} NodeIds.
- Preserve NodeIds for unchanged nodes by reconciling IDs between source and patched value; assign fresh IDs for new or structurally replaced nodes.
- Compute added/deleted via pre/post NodeId snapshots; compute updated for nodes with preserved NodeId where content/structure changed.
- Expose node_id in Python; update py_patch to return both the new value and a trace object.
- Update CLI and tests; add focused trace tests.

Rationale
- Enables downstream blame/provenance in asset360-rust based on NodeIds and per-stage PatchTrace. Core remains metadata-agnostic.

Notes
- py_patch currently returns a dict {"value": LinkMLValue, "trace": {...}}. If a tuple (value, trace) is preferred, I can switch.
- The implementation uses a robust snapshot + reconcile approach. A per-delta tracking version can be added later if needed for performance/precision.

CI
- `cargo test --workspace` passes locally.
